### PR TITLE
Convert === 0/0 into isnan

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -156,12 +156,12 @@ end
     end
     @test mean(Number[1, 1.5, 2+3im]) === 1.5+1im # mixed-type array
     @test mean(v for v in Number[1, 1.5, 2+3im]) === 1.5+1im
-    @test (@inferred mean(Int[])) === 0/0
-    @test (@inferred mean(Float32[])) === 0.f0/0    
-    @test (@inferred mean(Float64[])) === 0/0
-    @test (@inferred mean(Iterators.filter(x -> true, Int[]))) === 0/0
-    @test (@inferred mean(Iterators.filter(x -> true, Float32[]))) === 0.f0/0
-    @test (@inferred mean(Iterators.filter(x -> true, Float64[]))) === 0/0
+    @test isnan(@inferred mean(Int[]))
+    @test isnan(@inferred mean(Float32[]))
+    @test isnan(@inferred mean(Float64[]))
+    @test isnan(@inferred mean(Iterators.filter(x -> true, Int[])))
+    @test isnan(@inferred mean(Iterators.filter(x -> true, Float32[])))
+    @test isnan(@inferred mean(Iterators.filter(x -> true, Float64[])))
 end
 
 @testset "mean/median for ranges" begin


### PR DESCRIPTION
While the Julia interpreter folds 0/0 into 0xFFF8, LLVM optimizations occasionally constant fold 0/0 into 0x7FF8. Since the sign bit of a NaN is not required to have any particular value, we can use isnan instead of === 0/0 to check these tests. 