### PR TITLE
Allow for quantile to operate over an entire Matrix

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -958,19 +958,19 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     end
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
-quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
-    sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
+quantile!(a::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
+          sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(vec(a), p, sorted=sorted, alpha=alpha, beta=alpha)
 
-quantile!(q::AbstractArray, arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
-    sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(q, vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
+quantile!(q::AbstractArray, a::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
+          sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(q, vec(a), p, sorted=sorted, alpha=alpha, beta=alpha)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)
 
 # Function to perform partial sort of v for quantiles in given range
-function _quantilesort!(v::AbstractArray, sorted::Bool, minp::Real, maxp::Real)
+function _quantilesort!(v::AbstractVector, sorted::Bool, minp::Real, maxp::Real)
     isempty(v) && throw(ArgumentError("empty data vector"))
     require_one_based_indexing(v)
 
@@ -1079,6 +1079,7 @@ quantile(itr, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
 
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
+
 
 ##### SparseArrays optimizations #####
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -958,8 +958,9 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     end
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
-quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}}; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(arr[:], p, sorted=sorted, alpha=alpha, beta=alpha)
+quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
+          sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -958,7 +958,8 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     end
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
-quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}}; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) = quantile!(arr[:], p, sorted=sorted, alpha=alpha, beta=alpha)
+quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}}; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(arr[:], p, sorted=sorted, alpha=alpha, beta=alpha)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -958,6 +958,7 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     end
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
+quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}}; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) = quantile!(arr[:], p, sorted=sorted, alpha=alpha, beta=alpha)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -958,6 +958,9 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     end
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
+quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
+          sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)
@@ -1072,11 +1075,6 @@ quantile(itr, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
 
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
-
-quantile(arr::AbstractArray, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(sorted ? vec(arr) : Base.copymutable(vec(arr)), p; sorted=sorted, alpha=alpha, beta=beta)
-
-
 
 ##### SparseArrays optimizations #####
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1073,9 +1073,9 @@ quantile(itr, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
 
-quantile(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
-    sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
+quantile(arr::AbstractArray, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(sorted ? vec(arr) : Base.copymutable(vec(arr)), p; sorted=sorted, alpha=alpha, beta=beta)
+
 
 
 ##### SparseArrays optimizations #####

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -958,9 +958,6 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     end
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
-quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
-          sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)
@@ -1075,6 +1072,10 @@ quantile(itr, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
 
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
+
+quantile(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
+    sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
 
 
 ##### SparseArrays optimizations #####

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -959,10 +959,14 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
     return map(x->_quantile(v, x, alpha=alpha, beta=beta), p)
 end
 quantile!(arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
-          sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
 
-quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1., beta::Real=alpha) =
+quantile!(q::AbstractArray, arr::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
+    sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(q, vec(arr), p, sorted=sorted, alpha=alpha, beta=alpha)
+
+quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)
 
 # Function to perform partial sort of v for quantiles in given range

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -640,6 +640,11 @@ end
     @test quantile!(y, x, [0.1, 0.5, 0.9]) === y
     @test y ≈ [1.2, 2.0, 2.8]
 
+    x = reshape(collect(1:100), (10, 10))
+    y = zeros(5)
+    @test quantile!(y, x, [0.00, 0.25, 0.50, 0.75, 1.00]) === y
+    @test y ≈  [1.0, 25.75, 50.5, 75.25, 100.0]
+
     #tests for quantile calculation with configurable alpha and beta parameters
     v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -612,7 +612,9 @@ end
     @test quantile(Any[1, 2, 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, Float16(2), 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, big(2), 3], Float16(0.5)) isa BigFloat
-    @test quantile(reshape(collect(1:100), (10, 10)), [0.00, 0.25, 0.50, 0.75, 1.00]) == [1.0, 25.75, 50.5, 75.25, 100.0]
+
+    @test quantile(reshape(1:100, (10, 10)), [0.00, 0.25, 0.50, 0.75, 1.00]) ==
+        [1.0, 25.75, 50.5, 75.25, 100.0]
 
     # Need a large vector to actually check consequences of partial sorting
     x = rand(50)
@@ -643,7 +645,7 @@ end
     x = reshape(collect(1:100), (10, 10))
     y = zeros(5)
     @test quantile!(y, x, [0.00, 0.25, 0.50, 0.75, 1.00]) === y
-    @test y ≈  [1.0, 25.75, 50.5, 75.25, 100.0]
+    @test y ≈ [1.0, 25.75, 50.5, 75.25, 100.0]
 
     #tests for quantile calculation with configurable alpha and beta parameters
     v = [2, 3, 4, 6, 9, 2, 6, 2, 21, 17]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -612,6 +612,7 @@ end
     @test quantile(Any[1, 2, 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, Float16(2), 3], Float16(0.5)) isa Float16
     @test quantile(Any[1, big(2), 3], Float16(0.5)) isa BigFloat
+    @test quantile(reshape(collect(1:100), (10, 10)), [0.00, 0.25, 0.50, 0.75, 1.00]) == [1.0, 25.75, 50.5, 75.25, 100.0]
 
     # Need a large vector to actually check consequences of partial sorting
     x = rand(50)


### PR DESCRIPTION
As discussed [here](https://discourse.julialang.org/t/how-to-get-a-quick-description-of-a-vector-matrix-like-pd-dataframe-describe/78013/5) if you pass a matrix to `quantile` you get an error
```Julia
julia> quantile(reshape(collect(1:100), (10, 10)), [0.00, 0.25, 0.50, 0.75, 1.00])
ERROR: MethodError: no method matching quantile!(::Matrix{Int64}, ::Vector{Float64}; sorted=false, alpha=1.0, beta=1.0)
Closest candidates are:
  quantile!(::AbstractArray, ::AbstractVector, ::AbstractArray; sorted, alpha, beta) at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:936
  quantile!(::AbstractVector, ::Union{Tuple{Vararg{Real}}, AbstractArray}; sorted, alpha, beta) at /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:953
Stacktrace:
 [1] quantile(itr::Matrix{Int64}, p::Vector{Float64}; sorted::Bool, alpha::Float64, beta::Float64)
   @ Statistics /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:1070
 [2] quantile(itr::Matrix{Int64}, p::Vector{Float64})
   @ Statistics /Applications/Julia-1.7.app/Contents/Resources/julia/share/julia/stdlib/v1.7/Statistics/src/Statistics.jl:1070
 [3] top-level scope
   @ REPL[2]:1
```

I made a small change which vectorises a matrix and provides the quantile for the whole matrix. 

```Julia 
julia> quantile(reshape(collect(1:100), (10, 10)), [0.00, 0.25, 0.50, 0.75, 1.00])
5-element Vector{Float64}:
   1.0
  25.75
  50.5
  75.25
 100.0
```

This change was originally made in StatsBase with [PR 773](https://github.com/JuliaStats/StatsBase.jl/pull/773).