### PR TITLE
Remove unmatched parenthesis

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -347,7 +347,7 @@ The algorithm returns an estimator of the generative distribution's variance
 under the assumption that each entry of `itr` is a sample drawn from the same
 unknown distribution, with the samples uncorrelated.
 For arrays, this computation is equivalent to calculating
-`sum((itr .- mean(itr)).^2) / (length(itr) - 1))`.
+`sum((itr .- mean(itr)).^2) / (length(itr) - 1)`.
 If `corrected` is `true`, then the sum is scaled with `n-1`,
 whereas the sum is scaled with `n` if `corrected` is
 `false` where `n` is the number of elements in `itr`.


### PR DESCRIPTION
This PR removes an unmatched parenthesis in the end of an expression in the docstring for `var`.

The expression from the docstring is copied into an OhMyREPL-enabled REPL to highlight the removed parenthesis (red):
<img width="840" alt="image" src="https://user-images.githubusercontent.com/61620837/172569332-91dcd23a-032c-42aa-9fb2-8aadcc15e4e2.png">
