### PR TITLE
Prevent overflow in `mean(::AbstractRange)` and relax type constraint

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -182,9 +182,9 @@ function _mean(f, A::AbstractArray, dims::Dims=:) where Dims
     end
 end
 
-function mean(r::AbstractRange{<:Real})
-    isempty(r) && return oftype((first(r) + last(r)) / 2, NaN)
-    (first(r) + last(r)) / 2
+function mean(r::AbstractRange{T}) where T
+    isempty(r) && return zero(T)/0
+    return first(r)/2 + last(r)/2
 end
 
 median(r::AbstractRange{<:Real}) = mean(r)
@@ -997,9 +997,9 @@ end
     require_one_based_indexing(v)
 
     n = length(v)
-    
+
     @assert n > 0 # this case should never happen here
-    
+
     m = alpha + p * (one(alpha) - alpha - beta)
     aleph = n*p + oftype(p, m)
     j = clamp(trunc(Int, aleph), 1, n-1)
@@ -1012,7 +1012,7 @@ end
         a = v[j]
         b = v[j + 1]
     end
-    
+
     if isfinite(a) && isfinite(b)
         return a + γ*(b-a)
     else

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,8 +171,16 @@ end
             @test f(2:0.1:n) ≈ f([2:0.1:n;])
         end
     end
-    @test mean(2:1) === NaN
-    @test mean(big(2):1) isa BigFloat
+    @test mean(2:0.1:4) === 3.0  # N.B. mean([2:0.1:4;]) != 3
+    @test mean(LinRange(2im, 4im, 21)) === 3.0im
+    @test mean(2:1//10:4) === 3//1
+    @test isnan(@inferred(mean(2:1))::Float64)
+    @test isnan(@inferred(mean(big(2):1))::BigFloat)
+    z = @inferred(mean(LinRange(2im, 1im, 0)))::ComplexF64
+    @test isnan(real(z)) & isnan(imag(z))
+    @test_throws DivideError mean(2//1:1)
+    @test mean(typemax(Int):typemax(Int)) === float(typemax(Int))
+    @test mean(prevfloat(Inf):prevfloat(Inf)) === prevfloat(Inf)
 end
 
 @testset "var & std" begin
@@ -547,16 +555,16 @@ end
         @test cor(tmp, tmp) <= 1.0
         @test cor(tmp, tmp2) <= 1.0
     end
-    
+
     @test cor(Int[]) === 1.0
     @test cor([im]) === 1.0 + 0.0im
     @test_throws MethodError cor([])
     @test_throws MethodError cor(Any[1.0])
-    
+
     @test cor([1, missing]) === 1.0
     @test ismissing(cor([missing]))
     @test_throws MethodError cor(Any[1.0, missing])
-    
+
     @test Statistics.corm([true], 1.0) === 1.0
     @test_throws MethodError Statistics.corm(Any[0.0, 1.0], 0.5)
     @test Statistics.corzm([true]) === 1.0


### PR DESCRIPTION
Currently, `mean(::AbstractRange)` can overflow:
```julia
julia> using Statistics

julia> mean(typemax(Int):typemax(Int))
-1.0

julia> mean(prevfloat(Inf):prevfloat(Inf))
Inf
```

This PR prevents this overflow.

In addition, I've relaxed the type constraint from `AbstractRange{<:Real}` to `AbstractRange{<:Any}`, since the computation here is correct for any type that implements addition and numerical division (unlike the median, which requires an order). Currently, the mean of non-real ranges falls back to `mean(::AbstractVector)`, which also requires addition and numerical division.

In line with this, `oftype([...], NaN)` is changed to `zero(T)/0` so that `mean(LinRange(2im, 1im, 0))` is `NaN + NaN*im` (consistent with `mean(ComplexF64[])`) instead of `NaN + 0.0im`.