### PR TITLE
Improve `middle(::AbstractRange)` performance

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -765,21 +765,6 @@ equivalent in both value and type to computing their mean (`(x + y) / 2`).
 middle(x::Number, y::Number) = x/2 + y/2
 
 """
-    middle(range)
-
-Compute the middle of a range, which consists of computing the mean of its extrema.
-Since a range is sorted, the mean is performed with the first and last element.
-
-```jldoctest
-julia> using Statistics
-
-julia> middle(1:10)
-5.5
-```
-"""
-middle(a::AbstractRange) = middle(a[1], a[end])
-
-"""
     middle(a)
 
 Compute the middle of an array `a`, which consists of finding its
@@ -787,6 +772,9 @@ extrema and then computing their mean.
 
 ```jldoctest
 julia> using Statistics
+
+julia> middle(1:10)
+5.5
 
 julia> a = [1,2,3.6,10.9]
 4-element Vector{Float64}:
@@ -800,6 +788,11 @@ julia> middle(a)
 ```
 """
 middle(a::AbstractArray) = ((v1, v2) = extrema(a); middle(v1, v2))
+
+function middle(a::AbstractRange{<:Real})
+    isempty(a) && throw(ArgumentError("middle of an empty range is undefined."))
+    return mean(a)
+end
 
 """
     median!(v)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -791,7 +791,7 @@ middle(a::AbstractArray) = ((v1, v2) = extrema(a); middle(v1, v2))
 
 function middle(a::AbstractRange)
     isempty(a) && throw(ArgumentError("middle of an empty range is undefined."))
-    return middle(first(r), last(r))
+    return middle(first(a), last(a))
 end
 
 """
@@ -990,9 +990,9 @@ end
     require_one_based_indexing(v)
 
     n = length(v)
-    
+
     @assert n > 0 # this case should never happen here
-    
+
     m = alpha + p * (one(alpha) - alpha - beta)
     aleph = n*p + oftype(p, m)
     j = clamp(trunc(Int, aleph), 1, n-1)
@@ -1005,7 +1005,7 @@ end
         a = v[j]
         b = v[j + 1]
     end
-    
+
     if isfinite(a) && isfinite(b)
         return a + γ*(b-a)
     else

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -765,7 +765,7 @@ equivalent in both value and type to computing their mean (`(x + y) / 2`).
 middle(x::Number, y::Number) = x/2 + y/2
 
 """
-    middle(a)
+    middle(a::AbstractArray)
 
 Compute the middle of an array `a`, which consists of finding its
 extrema and then computing their mean.
@@ -791,7 +791,7 @@ middle(a::AbstractArray) = ((v1, v2) = extrema(a); middle(v1, v2))
 
 function middle(a::AbstractRange)
     isempty(a) && throw(ArgumentError("middle of an empty range is undefined."))
-    return mean(a)
+    return middle(first(r), last(r))
 end
 
 """

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -789,7 +789,7 @@ julia> middle(a)
 """
 middle(a::AbstractArray) = ((v1, v2) = extrema(a); middle(v1, v2))
 
-function middle(a::AbstractRange{<:Real})
+function middle(a::AbstractRange)
     isempty(a) && throw(ArgumentError("middle of an empty range is undefined."))
     return mean(a)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,8 +22,8 @@ Random.seed!(123)
         @test middle(one(T)) === middle(one(T), one(T))
     end
 
-    @test_throws Exception middle(Int[])
-    @test_throws Exception middle(1:0)
+    @test_throws MethodError middle(Int[])
+    @test_throws ArgumentError middle(1:0)
 end
 
 @testset "median" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,7 +22,11 @@ Random.seed!(123)
         @test middle(one(T)) === middle(one(T), one(T))
     end
 
-    @test_throws MethodError middle(Int[])
+    if VERSION < v"1.8.0-DEV.1343"
+        @test_throws ArgumentError middle(Int[])
+    else
+        @test_throws MethodError middle(Int[])
+    end
     @test_throws ArgumentError middle(1:0)
 end
 
@@ -550,16 +554,16 @@ end
         @test cor(tmp, tmp) <= 1.0
         @test cor(tmp, tmp2) <= 1.0
     end
-    
+
     @test cor(Int[]) === 1.0
     @test cor([im]) === 1.0 + 0.0im
     @test_throws MethodError cor([])
     @test_throws MethodError cor(Any[1.0])
-    
+
     @test cor([1, missing]) === 1.0
     @test ismissing(cor([missing]))
     @test_throws MethodError cor(Any[1.0, missing])
-    
+
     @test Statistics.corm([true], 1.0) === 1.0
     @test_throws MethodError Statistics.corm(Any[0.0, 1.0], 0.5)
     @test Statistics.corzm([true]) === 1.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -24,8 +24,6 @@ Random.seed!(123)
 
     @test_throws Exception middle(Int[])
     @test_throws Exception middle(1:0)
-    @test_throws MethodError middle([1.0im, 2.0im])
-    @test_throws MethodError middle(LinRange(1.0im, 2.0im, 2))
 end
 
 @testset "median" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,11 @@ Random.seed!(123)
     for T in [Bool,Int8,Int16,Int32,Int64,Int128,UInt8,UInt16,UInt32,UInt64,UInt128,Float16,Float32,Float64]
         @test middle(one(T)) === middle(one(T), one(T))
     end
+
+    @test_throws Exception middle(Int[])
+    @test_throws Exception middle(1:0)
+    @test_throws MethodError middle([1.0im, 2.0im])
+    @test_throws MethodError middle(LinRange(1.0im, 2.0im, 2))
 end
 
 @testset "median" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,8 @@ Random.seed!(123)
         @test_throws MethodError middle(Int[])
     end
     @test_throws ArgumentError middle(1:0)
+
+    @test middle(0:typemax(Int)) === typemax(Int) / 2
 end
 
 @testset "median" begin


### PR DESCRIPTION
Currently, the behavior of `middle` is inconsistent between ranges and vectors with non-`Real` eltypes:
```julia
julia> using Statistics

julia> r = LinRange(1im, 2im, 2)
2-element LinRange{ComplexF64, Int64}:
 0.0+1.0im,0.0+2.0im

julia> middle(r)
0.0 + 1.5im

julia> middle(collect(r))
ERROR: MethodError: no method matching isless(::ComplexF64, ::ComplexF64)
[...]
```

This PR fixes this by restricting `middle(::AbstractRange)` to `Real` eltypes. Performance is improved by calling `mean`, which elides bounds checks and does not call `length` (which is slow for `StepRange`).

Also, the doc for `middle(range)` is incorrect since ranges are not always sorted (there might not be a canonical order on the eltype, as above), so I've removed it and moved its example to the `middle(array)` doc.