### PR TITLE
Fix overflow in `mean(::AbstractRange)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+Manifest.toml

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -183,8 +183,9 @@ function _mean(f, A::AbstractArray, dims::Dims=:) where Dims
 end
 
 function mean(r::AbstractRange{<:Real})
-    isempty(r) && return oftype((first(r) + last(r)) / 2, NaN)
-    (first(r) + last(r)) / 2
+    centralval = first(r) + (last(r) - first(r)) / 2
+    isempty(r) && return oftype(centralval, NaN)
+    centralval
 end
 
 median(r::AbstractRange{<:Real}) = mean(r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -182,6 +182,15 @@ end
     end
     @test mean(2:1) === NaN
     @test mean(big(2):1) isa BigFloat
+
+    @testset "issue #120" begin
+        @test mean(Int8(123):Int8(123)) == 123
+        @test median(Int8(123):Int8(123)) == 123
+        @test mean(Int8(126):Int8(127)) == 126.5
+        @test mean(typemax(Int):typemax(Int)) == float(typemax(Int))
+        @test mean(UInt8(255):UInt8(255)) == 255
+        @test mean(Float16(12345):Float16(54321)) ≈ Float16(mean(Float32(12345):Float32(54321)))
+    end
 end
 
 @testset "var & std" begin


### PR DESCRIPTION
Fixes #120, now
```julia
julia> mean(Int8(123):Int8(123))
123.0
```