### PR TITLE
Fix building docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
       - run: |
           julia --project=docs -e '
             using Pkg
+            Pkg.respect_sysimage_versions(false)
             Pkg.develop(PackageSpec(path=pwd()))
             Pkg.instantiate()'
       - run: julia --project=docs docs/make.jl


### PR DESCRIPTION
Julia 1.8 throws an error by default when trying to install a package which is in the sysimage.