### PR TITLE
Fix hint on mean(::Number, ::Number)

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -103,12 +103,12 @@ julia> mean(√, [1 2 3; 4 5 6], dims=2)
 """
 mean(f, A::AbstractArray; dims=:) = _mean(f, A, dims)
 
-function Statistics.mean(f::Number, itr::Number)
+function mean(f::Number, itr::Number)
     f_value = try
         f(itr)
     catch MethodError
-        rethrow(ArgumentError("mean(f, itr) requires a function and an iterable.
-       Perhaps you meant middle(x, y)?"))
+        rethrow(ArgumentError("""mean(f, itr) requires a function and an iterable.
+                                 Perhaps you meant middle(x, y)?""",))
     end
     Base.reduce_first(+, f_value)/1
 end

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -103,6 +103,16 @@ julia> mean(√, [1 2 3; 4 5 6], dims=2)
 """
 mean(f, A::AbstractArray; dims=:) = _mean(f, A, dims)
 
+function Statistics.mean(f::Number, itr::Number)
+    f_value = try
+        f(itr)
+    catch MethodError
+        rethrow(ArgumentError("mean(f, itr) requires a function and an iterable.
+       Perhaps you meant middle(x, y)?"))
+    end
+    Base.reduce_first(+, f_value)/1
+end
+
 """
     mean!(r, v)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -171,6 +171,14 @@ end
     @test isnan(@inferred mean(Iterators.filter(x -> true, Int[])))
     @test isnan(@inferred mean(Iterators.filter(x -> true, Float32[])))
     @test isnan(@inferred mean(Iterators.filter(x -> true, Float64[])))
+
+    # using a number as a "function"
+    @test_throws "ArgumentError: mean(f, itr) requires a function and an iterable.\nPerhaps you meant middle(x, y)" mean(1, 2)
+    struct T <: Number
+        x::Int
+    end
+    (t::T)(y) = t.x * y
+    @test @inferred mean(T(2), 3) == 6
 end
 
 @testset "mean/median for ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -178,7 +178,7 @@ end
         x::Int
     end
     (t::T)(y) = t.x * y
-    @test @inferred mean(T(2), 3) == 6
+    @test @inferred mean(T(2), 3) === 6.0
 end
 
 @testset "mean/median for ranges" begin


### PR DESCRIPTION
Back before I know about `middle`, I tried `mean(1, 2)` and was briefly confused before settling on `mean((1, 2))` or `mean([1, 2])`. A better hint in the error message would have helped me.

Before:
```julia
julia> mean(1, 2)
ERROR: MethodError: objects of type Int64 are not callable
Maybe you forgot to use an operator such as *, ^, %, / etc. ?
Stacktrace:
[...]
```
After:
```julia
julia> mean(1, 2)
ERROR: ArgumentError: mean(f, itr) requires a function and an iterable.
       Perhaps you meant middle(x, y)?
Stacktrace:
[...]
```

Fixes #99 