### PR TITLE
Restrict type of f in `mean(f, itr)`

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -58,7 +58,7 @@ julia> mean([√1, √2, √3])
 1.3820881233139908
 ```
 """
-function mean(f, itr)
+function mean(f::Function, itr)
     y = iterate(itr)
     if y === nothing
         return Base.mapreduce_empty_iter(f, +, itr,


### PR DESCRIPTION
A naive user (like me) might expect there to be a vararg method for `mean`, which computes the mean of all arguments if they are numbers [1]. However, if one tries to do that, a not-so-helpful error is produced:
```
julia> mean(1, 1)
ERROR: MethodError: objects of type Int64 are not callable
Maybe you forgot to use an operator such as *, ^, %, / etc. ?
Stacktrace:
 [1] mean(f::Int64, itr::Int64)
   @ Statistics ~/.julia/juliaup/julia-1.9.0-rc2+0.x64.linux.gnu/share/julia/stdlib/v1.9/Statistics/src/Statistics.jl:69
 [2] top-level scope
   @ REPL[9]:1
```

This PR restricts the type of `f`, so that an appropriate `MethodError` should be thrown (I have not tested).

[1] An alternative fix would be to define such a method, as in `mean(args::Number...) = mean([args...])`. I am not sure what is preferable, but the suggested PR seems more clear.