### PR TITLE
Recommend `mean((x, y))` rather than `middle((x, y))`

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -107,9 +107,13 @@ if !isdefined(Base, :mean)
     function mean(f::Number, itr::Number)
         f_value = try
             f(itr)
-        catch MethodError
-            rethrow(ArgumentError("""mean(f, itr) requires a function and an iterable.
-                                    Perhaps you meant mean((x, y))?"""))
+        catch err
+            if err isa MethodError && err.f === f
+                rethrow(ArgumentError("""mean(f, itr) requires a function and an iterable.
+                                         Perhaps you meant mean((x, y))?"""))
+            else
+                rethrow(err)
+            end
         end
         Base.reduce_first(+, f_value)/1
     end

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -108,7 +108,7 @@ if !isdefined(Base, :mean)
         f_value = try
             f(itr)
         catch err
-            if err isa MethodError && err.f === f
+            if err isa MethodError && err.f === f && err.args == (itr,)
                 rethrow(ArgumentError("""mean(f, itr) requires a function and an iterable.
                                          Perhaps you meant mean((x, y))?"""))
             else

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -109,7 +109,7 @@ if !isdefined(Base, :mean)
             f(itr)
         catch MethodError
             rethrow(ArgumentError("""mean(f, itr) requires a function and an iterable.
-                                    Perhaps you meant middle(x, y)?""",))
+                                    Perhaps you meant mean((x, y))?"""))
         end
         Base.reduce_first(+, f_value)/1
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -179,7 +179,7 @@ end
     end
     (t::T)(y) = t.x == 0 ? t(y, y + 1, y + 2) : t.x * y
     @test mean(T(2), 3) === 6.0
-    err = @test_throws MethodError mean(T(0), 3)
+    @test_throws MethodError mean(T(0), 3)
     struct U <: Number
         x::Int
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -173,7 +173,7 @@ end
     @test isnan(@inferred mean(Iterators.filter(x -> true, Float64[])))
 
     # using a number as a "function"
-    @test_throws "ArgumentError: mean(f, itr) requires a function and an iterable.\nPerhaps you meant middle(x, y)" mean(1, 2)
+    @test_throws "ArgumentError: mean(f, itr) requires a function and an iterable.\nPerhaps you meant mean((x, y))" mean(1, 2)
     struct T <: Number
         x::Int
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,9 +177,14 @@ end
     struct T <: Number
         x::Int
     end
-    (t::T)(y) = t.x == 0 ? throw(MethodError(T)) : t.x * y
-    @test @inferred mean(T(2), 3) === 6.0
-    @test_throws MethodError mean(T(0), 3)
+    (t::T)(y) = t.x == 0 ? t(y, y + 1, y + 2) : t.x * y
+    @test mean(T(2), 3) === 6.0
+    err = @test_throws MethodError mean(T(0), 3)
+    struct U <: Number
+        x::Int
+    end
+    (t::U)(y) = t.x == 0 ? throw(MethodError(T)) : t.x * y
+    @test @inferred mean(U(2), 3) === 6.0
 end
 
 @testset "mean/median for ranges" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -177,8 +177,9 @@ end
     struct T <: Number
         x::Int
     end
-    (t::T)(y) = t.x * y
+    (t::T)(y) = t.x == 0 ? throw(MethodError(T)) : t.x * y
     @test @inferred mean(T(2), 3) === 6.0
+    @test_throws MethodError mean(T(0), 3)
 end
 
 @testset "mean/median for ranges" begin


### PR DESCRIPTION
It seems more logical and simpler for users to recommend using the same function. This also helps making Statistics a standalone package (JuliaStats/Statistics.jl#128) as `mean` will be moved to Julia Base, but `middle` will remain in Statistics.

This blocks https://github.com/JuliaLang/julia/pull/46501.

See https://github.com/JuliaStats/Statistics.jl/pull/131. Cc: @LilithHafner