### PR TITLE
Fix `quantile` with `Date` and `DateTime`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,9 +19,10 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SparseArraysExt = ["SparseArrays"]
 
 [extras]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "SparseArrays", "Test"]
+test = ["Dates", "Random", "SparseArrays", "Test"]

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1026,8 +1026,8 @@ end
 
     # When a ≉ b, b-a may overflow
     # When a ≈ b, (1-γ)*a + γ*b may not be increasing with γ due to rounding
-    # Call to float is to work around JuliaLang/julia#50380
-    if isfinite(a) && isfinite(b) && float(a) ≈ float(b)
+    if isfinite(a) && isfinite(b) &&
+        (!(a isa Number) || !(b isa Number) || a ≈ b)
         return a + γ*(b-a)
     else
         return (1-γ)*a + γ*b

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 # This file is a part of Julia. License is MIT: https://julialang.org/license
 
-using Statistics, Test, Random, LinearAlgebra, SparseArrays
+using Statistics, Test, Random, LinearAlgebra, SparseArrays, Dates
 using Test: guardseed
 
 Random.seed!(123)
@@ -774,6 +774,17 @@ end
     @test issorted(quantile([1.0, 1.0, 1.0+eps(), 1.0+eps()], range(0, 1, length=100)))
     @test issorted(quantile([1.0, 1.0+1eps(), 1.0+2eps(), 1.0+3eps()], range(0, 1, length=100)))
     @test issorted(quantile([1.0, 1.0+2eps(), 1.0+4eps(), 1.0+6eps()], range(0, 1, length=100)))
+end
+
+@testset "quantiles with Date and DateTime" begin
+    # this is the historical behavior
+    @test quantile([Date(2023, 09, 02)], .1) == Date(2023, 09, 02)
+    @test quantile([Date(2023, 09, 02), Date(2023, 09, 02)], .1) == Date(2023, 09, 02)
+    @test_throws InexactError quantile([Date(2023, 09, 02), Date(2023, 09, 03)], .1)
+
+    @test quantile([DateTime(2023, 09, 02)], .1) == DateTime(2023, 09, 02)
+    @test quantile([DateTime(2023, 09, 02), DateTime(2023, 09, 02)], .1) == DateTime(2023, 09, 02)
+    @test_throws InexactError quantile([DateTime(2023, 09, 02), DateTime(2023, 09, 03)], .1)
 end
 
 @testset "variance of complex arrays (#13309)" begin


### PR DESCRIPTION
Before #145 `Date` and `DateTime` were supported with `quantile` as long as the cut point falls between two equal values. Restore this behavior as some code may rely on this given that it is the most common situation with large datasets.

(Failures on Julia 1.x are expected as the fix that allows dropping  `float` is only available on master. But we probably don't care as Statistics can only be upgraded on Julia 1.11 and later.)