### PR TITLE
Drop support for v1.9 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           #- '1' # automatically expands to the latest stable 1.x release of Julia
-          - '1.10'
+          #- '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1' # automatically expands to the latest stable 1.x release of Julia
+          #- '1' # automatically expands to the latest stable 1.x release of Julia
+          - '1.10'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       matrix:
         version:
           #- '1' # automatically expands to the latest stable 1.x release of Julia
-          #- '1.10'
+          - '~1.10.0-0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -6,7 +6,7 @@ desc = "Basic statistics for Julia."
 version = "1.11.0"
 
 [compat]
-julia = "1.9"
+julia = "1.9.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"


### PR DESCRIPTION
The package was already broken by https://github.com/JuliaStats/Statistics.jl/pull/153, so this merely updates the CI support matrix and compat bounds so that someone doesn't accidentally install a newer version than is supported by v1.9