### PR TITLE
CI: restore v1.9.4 to build matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          #- '1' # automatically expands to the latest stable 1.x release of Julia
+          - '1' # automatically expands to the latest stable 1.x release of Julia (currently 1.9.x)
           - '~1.10.0-0'
           - 'nightly'
         os:


### PR DESCRIPTION
Now that v1.9.4 is released