### PR TITLE
propagate NaN value in median

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -814,7 +814,8 @@ Like [`median`](@ref), but may overwrite the input vector.
 function median!(v::AbstractVector)
     isempty(v) && throw(ArgumentError("median of an empty array is undefined, $(repr(v))"))
     eltype(v)>:Missing && any(ismissing, v) && return missing
-    any(x -> x isa Number && isnan(x), v) && return convert(eltype(v), NaN)
+    nanix = findfirst(x -> x isa Number && isnan(x), v)
+    isnothing(nanix) || return v[nanix]
     inds = axes(v, 1)
     n = length(inds)
     mid = div(first(inds)+last(inds),2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,14 @@ end
     @test isnan(median(Any[NaN,0.0,1.0]))
     @test isequal(median([NaN 0.0; 1.2 4.5], dims=2), reshape([NaN; 2.85], 2, 1))
 
+    # the specific NaN value is propagated from the input
+    @test median([NaN]) === NaN
+    @test median([0.0,NaN]) === NaN
+    @test median([0.0,NaN,NaN]) === NaN
+    @test median([-NaN]) === -NaN
+    @test median([0.0,-NaN]) === -NaN
+    @test median([0.0,-NaN,-NaN]) === -NaN
+
     @test ismissing(median([1, missing]))
     @test ismissing(median([1, 2, missing]))
     @test ismissing(median([NaN, 2.0, missing]))
@@ -111,6 +119,14 @@ end
     @test isnan(mean([NaN]))
     @test isnan(mean([0.0,NaN]))
     @test isnan(mean([NaN,0.0]))
+
+    # the specific NaN value is propagated from the input
+    @test mean([NaN]) === NaN
+    @test mean([0.0,NaN]) === NaN
+    @test mean([0.0,NaN,NaN]) === NaN
+    @test mean([-NaN]) === -NaN
+    @test mean([0.0,-NaN]) === -NaN
+    @test mean([0.0,-NaN,-NaN]) === -NaN
 
     @test isnan(mean([0.,Inf,-Inf]))
     @test isnan(mean([1.,-1.,Inf,-Inf]))


### PR DESCRIPTION
Propagate a NaN value from the input array, instead of creating a NaN anew.

Fixes this error, for example:
```julia
julia> using Statistics, Unitful

julia> median([NaN*u"m"])
ERROR: DimensionError: m and NaN are not dimensionally compatible.
Stacktrace:
 [1] convert(::Type{Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}}, x::Float64)
   @ Unitful ~/.julia/packages/Unitful/R4J37/src/conversion.jl:106
 [2] median!(v::Vector{Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}})
   @ Statistics ~/.julia/juliaup/julia-1.10.2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:815
 [3] _median
   @ ~/.julia/juliaup/julia-1.10.2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:878 [inlined]
 [4] median(v::Vector{Quantity{Float64, 𝐋, Unitful.FreeUnits{(m,), 𝐋, nothing}}})
   @ Statistics ~/.julia/juliaup/julia-1.10.2+0.aarch64.apple.darwin14/share/julia/stdlib/v1.10/Statistics/src/Statistics.jl:874
 [5] top-level scope
   @ REPL[3]:1
```