### PR TITLE
Test earliest supported Julia version and prereleases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,31 +6,26 @@ on:
   pull_request:
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         version:
-          - '1' # automatically expands to the latest stable 1.x release of Julia
-          - 'lts'
+          - 'min' # earliest supported version of Julia
+          - '1' # latest v1 version of Julia
+          - 'lts' # latest LTS build of Julia
+          - 'pre' # latest prerelease build (RCs, betas, and alphas) of Julia
         os:
           - ubuntu-latest
-          - macOS-13
+          - macOS-latest
           - windows-latest
-        arch:
-          - x64
-        include:
-          - os: macOS-latest
-            arch: aarch64
-            version: '1'
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          include-all-prereleases: true
-          arch: ${{ matrix.arch }}
+          show-versioninfo: true
       - uses: julia-actions/cache@v2
       - run: julia --color=yes .ci/test_and_change_uuid.jl
       - uses: julia-actions/julia-buildpkg@v1


### PR DESCRIPTION
#167 removed tests on nightly and added the `include-prereleases` option. However, I think it would be better to test `pre` instead of setting this option: Otherwise, once a pre-release of Julia v1 is available, tests with `1` will only test the pre-release but the latest stable build will not be tested anymore.

Additionally, I think it would be good to test `min`, the earliest supported Julia version, as well to avoid accidentally breaking support for old Julia versions.