### PR TITLE
add methods for `median` and `quantile` with function as the first argument. Fixes #141

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1115,6 +1115,9 @@ julia> quantile(skipmissing([1, 10, missing]), 0.5)
 quantile(itr, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(collect(itr), p, sorted=sorted, alpha=alpha, beta=beta)
 
+quantile(f, v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
+    quantile!(f.(v), p; sorted=sorted, alpha=alpha, beta=beta)
+
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
 

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -904,6 +904,7 @@ _median(v::AbstractArray{T}, ::Colon) where {T} = median!(copyto!(Array{T,1}(und
 
 median(r::AbstractRange{<:Real}) = mean(r)
 
+median(f, v) = median!(f.(v))
 """
     quantile!([q::AbstractArray, ] v::AbstractVector, p; sorted=false, alpha::Real=1.0, beta::Real=alpha)
 


### PR DESCRIPTION
This PR adds `quantile(f, v)` and `median(f, v)` methods, where `f` is a function, and `v` is an abstract array. Fixes #141 