### PR TITLE
Fix `quantile` doctest

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,4 +2,4 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 
 [compat]
-Documenter = "0.24"
+Documenter = "1.8"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,8 +8,7 @@ end
 makedocs(
     modules = [Statistics],
     sitename = "Statistics",
-    checkdocs = :exports,
-    warnonly = :cross_references,
+    warnonly = [:missing_docs, :cross_references]
     pages = Any[
         "Statistics" => "index.md"
         ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,8 @@ end
 makedocs(
     modules = [Statistics],
     sitename = "Statistics",
+    checkdocs = :exports,
+    warnonly = :cross_references,
     pages = Any[
         "Statistics" => "index.md"
         ]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ end
 makedocs(
     modules = [Statistics],
     sitename = "Statistics",
-    warnonly = [:missing_docs, :cross_references]
+    warnonly = [:missing_docs, :cross_references],
     pages = Any[
         "Statistics" => "index.md"
         ]

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -962,9 +962,9 @@ true
 
 julia> y
 3-element Vector{Float64}:
- 1.2000000000000002
+ 1.2
  2.0
- 2.8000000000000003
+ 2.8
 ```
 """
 function quantile!(q::AbstractArray, v::AbstractVector, p::AbstractArray;
@@ -1106,7 +1106,7 @@ julia> quantile(0:20, [0.1, 0.5, 0.9])
 3-element Vector{Float64}:
   2.0
  10.0
- 18.000000000000004
+ 18.0
 
 julia> quantile(skipmissing([1, 10, missing]), 0.5)
 5.5


### PR DESCRIPTION
We should have updated the doctests when improving behavior at #184. Also update Documenter, which by default now fails when doctests fail.