### PR TITLE
Remove SparseArrays from deps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,7 +10,6 @@ julia = "1.9.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [weakdeps]
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1163,9 +1163,4 @@ quantile(f::Function, v, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alph
 quantile(v::AbstractVector, p; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     quantile!(sorted ? v : Base.copymutable(v), p; sorted=sorted, alpha=alpha, beta=beta)
 
-# If package extensions are not supported in this Julia version
-if !isdefined(Base, :get_extension)
-    include("../ext/SparseArraysExt.jl")
-end
-
 end # module


### PR DESCRIPTION
Statistics.jl  has minimum julia version 1.9, so this band-aid is not necessary anymore.

Should at once help  https://github.com/SciML/LinearSolve.jl/issues/573 