### PR TITLE
fix forwarding of `beta` kwarg in `quantile!(::AbstractArray...)`

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1013,11 +1013,11 @@ function quantile!(v::AbstractVector, p::Union{AbstractArray, Tuple{Vararg{Real}
 end
 quantile!(a::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
           sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(vec(a), p, sorted=sorted, alpha=alpha, beta=alpha)
+    quantile!(vec(a), p, sorted=sorted, alpha=alpha, beta=beta)
 
 quantile!(q::AbstractArray, a::AbstractArray, p::Union{AbstractArray,Tuple{Vararg{Real}}};
           sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
-    quantile!(q, vec(a), p, sorted=sorted, alpha=alpha, beta=alpha)
+    quantile!(q, vec(a), p, sorted=sorted, alpha=alpha, beta=beta)
 
 quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1.0, beta::Real=alpha) =
     _quantile(_quantilesort!(v, sorted, p, p), p, alpha=alpha, beta=beta)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -820,6 +820,10 @@ end
         @test [quantile(1:10, i/9) for i in 0:9] == 1:10
         @test [quantile(1:14, i/13) for i in 0:13] == 1:14
     end
+    # Statistics issue 204
+    @testset "vector and abstract array methods should agree" begin
+        @test quantile!(reshape([1.,2,3,4,5],5,1), [.25,.5,.75]; alpha=0, beta=1) ≈ [1.25, 2.5, 3.75]
+    end
 end
 
 # StatsBase issue 164

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -820,6 +820,7 @@ end
         @test [quantile(1:10, i/9) for i in 0:9] == 1:10
         @test [quantile(1:14, i/13) for i in 0:13] == 1:14
     end
+
     # Statistics issue 204
     @testset "vector and abstract array methods should agree" begin
         @test quantile!(reshape([1.,2,3,4,5],5,1), [.25,.5,.75]; alpha=0, beta=1) ≈ [1.25, 2.5, 3.75]


### PR DESCRIPTION
Closes https://github.com/JuliaStats/Statistics.jl/issues/204

Before:
```julia
julia> quantile!(reshape([1.,2,3,4,5],5,1), [.25,.5,.75]; alpha=0, beta=1) ≈ quantile!([1.,2,3,4,5], [.25,.5,.75]; alpha=0, beta=1)
false
```
after
```julia
julia> quantile!(reshape([1.,2,3,4,5],5,1), [.25,.5,.75]; alpha=0, beta=1) ≈ quantile!([1.,2,3,4,5], [.25,.5,.75]; alpha=0, beta=1)
true
```