### PR TITLE
Throw a clear error for degenerate-length data vectors (fixes #121)

### DIFF
--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -1026,6 +1026,10 @@ quantile!(v::AbstractVector, p::Real; sorted::Bool=false, alpha::Real=1.0, beta:
 function _quantilesort!(v::AbstractVector, sorted::Bool, minp::Real, maxp::Real)
     isempty(v) && throw(ArgumentError("empty data vector"))
     require_one_based_indexing(v)
+    length(v) == 0 && throw(ArgumentError(
+        "data vector reports length 0 but is not empty; this can happen for an " *
+        "integer range whose length overflows (e.g. `typemin(Int):typemax(Int)`) — " *
+        "collect it to a concrete vector first"))
 
     if !sorted
         lv = length(v)
@@ -1051,7 +1055,7 @@ end
 
     n = length(v)
 
-    @assert n > 0 # this case should never happen here
+    n > 0 || throw(ArgumentError("quantile is undefined for a length-0 data vector"))
 
     m = alpha + p * (one(alpha) - alpha - beta)
     # Using fma here avoids some rounding errors when aleph is an integer

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -714,6 +714,17 @@ end
     @test quantile(skipmissing([1, missing, 2]), 0.5) === 1.5
     @test quantile([1], 0.5) === 1.0
 
+    # A range whose length overflows reports length 0 while being non-empty,
+    # which slips past the isempty guard. Such input gets a clear ArgumentError
+    # instead of an internal AssertionError (issue #121).
+    let r = typemin(Int):typemax(Int)
+        @test length(r) == 0
+        @test !isempty(r)
+        @test_throws ArgumentError quantile!([0], r, [1])
+        @test_throws ArgumentError quantile(r, 0.5; sorted=true)
+    end
+    @test_throws ArgumentError quantile(Int[], 0.5)
+
     # make sure that type inference works correctly in normal cases
     for T in [Int, BigInt, Float64, Float16, BigFloat, Rational{Int}, Rational{BigInt}]
         for S in [Float64, Float16, BigFloat, Rational{Int}, Rational{BigInt}]


### PR DESCRIPTION

Give `quantile!` a clear `ArgumentError` instead of an internal `AssertionError`
for a data vector that reports `length 0` while not being empty, fixing #121.

An integer range whose length overflows (e.g. `typemin(Int):typemax(Int)`) has
`length == 0` but `isempty == false`. Such input passes the `isempty` guard in
`_quantilesort!` and then trips `@assert n > 0` inside `_quantile`, whose comment
claims the case "should never happen here".

This adds a `length(v) == 0` guard in `_quantilesort!` (covering both `quantile!`
entry points before any `_quantile` call) that throws an `ArgumentError` pointing
the user at the overflow and suggesting they collect to a concrete vector first.
The now-redundant `@assert` in `_quantile` becomes a defensive `ArgumentError`,
which also keeps the check under `--check-bounds=no` where `@assert` may be elided.

```julia
r = typemin(Int):typemax(Int)
quantile!([0], r, [1])        # ArgumentError, was AssertionError
quantile(r, 0.5; sorted=true) # ArgumentError, was BoundsError
```

The default `quantile(r, 0.5)` path is unchanged: it materializes the range via
`Base.copymutable` first, which errors before reaching this code; that is a
separate, appropriate failure for a range claiming 2^64 elements.

Tests cover both overflow paths and confirm the existing empty-vector behavior
(`ArgumentError("empty data vector")`) still fires.
