### PR TITLE
Test against Julia nightly in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,7 @@ jobs:
           - '1' # latest v1 version of Julia
           - 'lts' # latest LTS build of Julia
           - 'pre' # latest prerelease build (RCs, betas, and alphas) of Julia
+          - 'nightly' # nightly build of Julia
         os:
           - ubuntu-latest
           - macOS-latest

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -257,10 +257,6 @@ function _var(iterable, corrected::Bool, mean)
     end
 end
 
-# Whether R has a single element along its first dimension. Defined here instead
-# of using the internal Base.reducedim1 whose signature changed in Julia 1.14
-reducedim1(R) = length(Base.axes1(R)) == 1
-
 centralizedabs2fun(m) = x -> abs2.(x - m)
 centralize_sumabs2(A::AbstractArray, m) =
     mapreduce(centralizedabs2fun(m), +, A)
@@ -289,7 +285,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::Abstr
     end
     indsAt, indsRt = Base.safe_tail(axes(A)), Base.safe_tail(axes(R)) # handle d=1 manually
     keep, Idefault = Broadcast.shapeindexer(indsRt)
-    if reducedim1(R)
+    if length(Base.axes1(R)) == 1
         i1 = first(Base.axes1(R))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)

--- a/src/Statistics.jl
+++ b/src/Statistics.jl
@@ -257,6 +257,10 @@ function _var(iterable, corrected::Bool, mean)
     end
 end
 
+# Whether R has a single element along its first dimension. Defined here instead
+# of using the internal Base.reducedim1 whose signature changed in Julia 1.14
+reducedim1(R) = length(Base.axes1(R)) == 1
+
 centralizedabs2fun(m) = x -> abs2.(x - m)
 centralize_sumabs2(A::AbstractArray, m) =
     mapreduce(centralizedabs2fun(m), +, A)
@@ -285,7 +289,7 @@ function centralize_sumabs2!(R::AbstractArray{S}, A::AbstractArray, means::Abstr
     end
     indsAt, indsRt = Base.safe_tail(axes(A)), Base.safe_tail(axes(R)) # handle d=1 manually
     keep, Idefault = Broadcast.shapeindexer(indsRt)
-    if Base.reducedim1(R, A)
+    if reducedim1(R)
         i1 = first(Base.axes1(R))
         @inbounds for IA in CartesianIndices(indsAt)
             IR = Broadcast.newindex(IA, keep, Idefault)


### PR DESCRIPTION
Adds `nightly` to the CI version matrix so the package is also tested against nightly builds of Julia on all three platforms.

The nightly jobs initially failed because the internal `Base.reducedim1` changed signature from `reducedim1(R, A)` to `reducedim1(R)` on nightly (#208). Since the second argument was always unused and the function is a one-liner, this PR defines it locally in Statistics.jl, which works on all supported Julia versions.

Fixes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)