### PR TITLE
test: Do not assert which NaN `mean` returns

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,7 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 keywords = ["statistics"]
 license = "MIT"
 desc = "Basic statistics for Julia."
-version = "1.11.4"
+version = "1.11.5"
 
 [compat]
 julia = "1.9.4"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -119,14 +119,9 @@ end
     @test isnan(mean([NaN]))
     @test isnan(mean([0.0,NaN]))
     @test isnan(mean([NaN,0.0]))
-
-    # the specific NaN value is propagated from the input
-    @test mean([NaN]) === NaN
-    @test mean([0.0,NaN]) === NaN
-    @test mean([0.0,NaN,NaN]) === NaN
-    @test mean([-NaN]) === -NaN
-    @test mean([0.0,-NaN]) === -NaN
-    @test mean([0.0,-NaN,-NaN]) === -NaN
+    @test isnan(mean([-NaN]))
+    @test isnan(mean([0.0,-NaN]))
+    @test isnan(mean([0.0,-NaN,-NaN]))
 
     @test isnan(mean([0.,Inf,-Inf]))
     @test isnan(mean([1.,-1.,Inf,-Inf]))


### PR DESCRIPTION
Julia does not specify the sign or payload of a NaN produced by floating-point arithmetic, and LLVM explicitly permits both to vary. RISC-V canonicalizes NaN results from ordinary arithmetic, so the exact-equality assertions fail there even though `mean` correctly returns a NaN (JuliaLang/julia#56672).

Check only that the negative-NaN inputs produce a NaN, consistent with the existing positive-NaN coverage.